### PR TITLE
chore: bump pipestream BOM to 0.7.24-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ org.gradle.warning.mode=summary
 
 # Pipestream BOM version - single source of truth for this consumer project
 # Update this when upgrading to a new pipestream-platform release
-pipestreamBomVersion=0.7.23
+pipestreamBomVersion=0.7.24-SNAPSHOT


### PR DESCRIPTION
Consumes the round-robin channel pool + dynamic-grpc counter cache landed in pipestream-platform PR #70 (commit b871a3a, 0.7.24-SNAPSHOT).